### PR TITLE
SPL Prep

### DIFF
--- a/fixtures/body_collision.json
+++ b/fixtures/body_collision.json
@@ -6,7 +6,8 @@
             "name": "standard",
             "version": "bees"
 
-        }
+        },
+        "timeout": 500
     },
     "you": {
                 "id": "bees",

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -287,17 +287,23 @@ pub struct CellBoard<T: CellNum, const BOARD_SIZE: usize, const MAX_SNAKES: usiz
 /// Used to represent the standard 11x11 game with up to 4 snakes.
 pub type CellBoard4Snakes11x11 = CellBoard<u8, { 11 * 11 }, 4>;
 
+/// Used to represent the a 15x15 board with up to 4 snakes. This is the biggest board size that
+/// can still use u8s
+pub type CellBoard8Snakes15x15 = CellBoard<u8, { 15 * 15 }, 8>;
+
 /// Used to represent the largest UI Selectable board with 8 snakes.
-pub type CellBoard8Snakes25x25 = CellBoard<u8, { 25 * 25 }, 8>;
+pub type CellBoard8Snakes25x25 = CellBoard<u16, { 25 * 25 }, 8>;
 
 /// Used to represent an absolutely silly game board
-pub type CellBoard16Snakes50x50 = CellBoard<u8, { 50 * 50 }, 16>;
+pub type CellBoard16Snakes50x50 = CellBoard<u16, { 50 * 50 }, 16>;
 
 /// Enum that holds a Cell Board sized right for the given game
 #[derive(Debug)]
 pub enum BestCellBoard {
     #[allow(missing_docs)]
     Standard(Box<CellBoard4Snakes11x11>),
+    #[allow(missing_docs)]
+    LargestU8(Box<CellBoard8Snakes15x15>),
     #[allow(missing_docs)]
     Large(Box<CellBoard8Snakes25x25>),
     #[allow(missing_docs)]
@@ -318,6 +324,10 @@ impl ToBestCellBoard for Game {
 
         let best_board = if required_board_size <= (11 * 11) && num_snakes <= 4 {
             BestCellBoard::Standard(Box::new(CellBoard4Snakes11x11::convert_from_game(
+                self, &id_map,
+            )?))
+        } else if required_board_size <= (15 * 15) && num_snakes <= 8 {
+            BestCellBoard::LargestU8(Box::new(CellBoard8Snakes15x15::convert_from_game(
                 self, &id_map,
             )?))
         } else if required_board_size <= (25 * 25) && num_snakes <= 8 {

--- a/src/compact_representation/mod.rs
+++ b/src/compact_representation/mod.rs
@@ -310,7 +310,10 @@ pub enum BestCellBoard {
     Silly(Box<CellBoard16Snakes50x50>),
 }
 
-/// Trait to get the best sized cellboard for the given game
+/// Trait to get the best sized cellboard for the given game. It returns the smallest Compact board
+/// that has enough room to fit the given Wire game. If the game can't fit in any of our Compact
+/// boards we panic. However the largest board available is MUCH larger than the biggest selectable
+/// board in the Battlesnake UI
 pub trait ToBestCellBoard {
     #[allow(missing_docs)]
     fn to_best_cell_board(self) -> Result<BestCellBoard, Box<dyn Error>>;

--- a/src/wire_representation/mod.rs
+++ b/src/wire_representation/mod.rs
@@ -113,6 +113,7 @@ impl fmt::Display for Board {
 pub struct NestedGame {
     pub id: String,
     pub ruleset: Ruleset,
+    pub timeout: i64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
I'm prepping for Snake Pit Live where who knows what to expect!

My first step was reading the timeout value from the server instead of
using my hard coded values.

Then I wanted to be able to run off bigger board sizes, but I didn't want to _have_ to use a bigger board if the Game could fit in the Standard board.

So I created a few more of the alias types, and then a trait that can be used to pick the smallest Compact board that can fit the given wire board.

This works well with my snakes since they are already not using the concrete types, so all of these different 'sizes' just slot in nicely.

I also made some small changes to the compact board to support non-square boards, and allow a smaller board to work as long as it fits inside the size constraints. This required adding two more `u8`s to the struct to store the actual width and height of the Game. These are used to calculate is a Cell is off the board, and in the Display representation to print out the correct ASCII grid

Copied from: https://github.com/penelopezone/battlesnake-game-types/pull/2